### PR TITLE
Allow specification of public ipv4 pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ The solution processes EIPs for Pods through the following steps:
 
 ## Annotations
 
-| Name                                                 | Type   | Default  | Location |
-|------------------------------------------------------|--------|----------|----------|
-| aws-samples.github.com/aws-pod-eip-controller-type   | string | auto     | pod      |
+| Name                                                           | Type   | Default  | Location |
+|----------------------------------------------------------------|--------|----------|----------|
+| aws-samples.github.com/aws-pod-eip-controller-type             | string | auto     | pod      |
+| aws-samples.github.com/aws-pod-eip-controller-public-ipv4-pool | string |          | pod      |
 
 ## Config
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -3,9 +3,10 @@ package pkg
 const (
 	// Kubernetes annotations/labels
 
-	PodEIPAnnotationKey   = "aws-samples.github.com/aws-pod-eip-controller-type"
-	PodEIPAnnotationValue = "auto"
-	PodPublicIPLabel      = "aws-pod-eip-controller-public-ip"
+	PodEIPAnnotationKey         = "aws-samples.github.com/aws-pod-eip-controller-type"
+	PodEIPAnnotationValue       = "auto"
+	PodAddressPoolAnnotationKey = "aws-samples.github.com/aws-pod-eip-controller-public-ipv4-pool"
+	PodPublicIPLabel            = "aws-pod-eip-controller-public-ip"
 
 	// AWS Tags
 


### PR DESCRIPTION
Adds an optional annotation to specify the public ipv4 pool to use.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
