### PR TITLE
feat: disable pod eip reclaim && support fixed public eip

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The solution processes EIPs for Pods through the following steps:
 |----------------------------------------------------------------|--------|----------|----------|
 | aws-samples.github.com/aws-pod-eip-controller-type             | string | auto     | pod      |
 | aws-samples.github.com/aws-pod-eip-controller-public-ipv4-pool | string |          | pod      |
+| aws-samples.github.com/aws-pod-eip-controller-type             | string | auto     | pod      |
+| aws-samples.github.com/aws-pod-eip-controller-mode             | string | nil      | pod      |
+| aws-samples.github.com/aws-pod-eip-controller-reclaim          | string | nil      | pod      |
+
 
 ## Config
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -5,6 +5,10 @@ const (
 
 	PodEIPAnnotationKey         = "aws-samples.github.com/aws-pod-eip-controller-type"
 	PodEIPAnnotationValue       = "auto"
+	PodEIPReclaimAnnotationKey  = "aws-samples.github.com/aws-pod-eip-controller-reclaim"
+	PodEIPReclaimAnnotationVal  = "false"
+	PodEIPModeAnnotationKey     = "aws-samples.github.com/aws-pod-eip-controller-mode"
+	PodEIPModeAnnotationVal     = "fixed"
 	PodAddressPoolAnnotationKey = "aws-samples.github.com/aws-pod-eip-controller-public-ipv4-pool"
 	PodPublicIPLabel            = "aws-pod-eip-controller-public-ip"
 

--- a/pkg/k8s/controller.go
+++ b/pkg/k8s/controller.go
@@ -147,6 +147,7 @@ func (c *PodController) toPod(key string, obj interface{}) pod {
 
 	v1Pod := *obj.(*v1.Pod)
 	var hasEIPAnnotation bool
+
 	if v, ok := v1Pod.Annotations[pkg.PodEIPAnnotationKey]; ok && v == pkg.PodEIPAnnotationValue {
 		hasEIPAnnotation = true
 	}

--- a/pkg/k8s/worker.go
+++ b/pkg/k8s/worker.go
@@ -5,11 +5,12 @@ package k8s
 
 import (
 	"fmt"
-	"k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 	"log/slog"
 	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 )
 
 const maxQueueRetries = 3

--- a/pkg/k8s/worker_test.go
+++ b/pkg/k8s/worker_test.go
@@ -5,10 +5,11 @@ package k8s
 
 import (
 	"errors"
-	"github.com/stretchr/testify/mock"
-	"k8s.io/api/core/v1"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/mock"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestPodWorker_processNextItem(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-pod-eip-controller/issues/84

We have a use case where we utilize fixed Elastic IP addresses in AWS, and we believe that other users may encounter similar situations. In this PR, I have implemented the technical solution to allow users to use both fixed Elastic IP and random Elastic IP modes through annotations.

*Description of changes:*
Support fixed public eip for controller.

To achieve a fixed public EIP in AWS eip controller, you can follow these steps:
1. Allocate an Elastic IP address: Use the AWS Management Console, or patch annotataion to pod in order to allocate an Elastic IP address. This reserves a specific public IP address within Amazon's pool of addresses.
2. Associate the Elastic IP address with pod: Associate the allocated Elastic IP address with the desired pod via annotation. This ensures the instance is reachable through the fixed public IP address. 

```
cat << EOF > no-reclaim-eip-sts.yaml
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: no-reclaim-eip-sts
  namespace: lexus-test
spec:
  replicas: 2
  selector:
    matchLabels:
      app: no-reclaim-eip-sts
  template:
    metadata:
      labels:
        app: no-reclaim-eip-sts
      annotations:
        aws-samples.github.com/aws-pod-eip-controller-mode: "fixed"
        aws-samples.github.com/aws-pod-eip-controller-type: auto
    spec:
      containers:
      - name: nginx-app-container
        image: nginx
EOF
kubectl apply -f no-reclaim-eip-sts.yaml        
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
