### PR TITLE
Update Dockerfile - fix the warning  "1 warning found (use --debug to expand):  - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.23.1-bullseye as builder
+FROM public.ecr.aws/docker/library/golang:1.23.1-bullseye AS builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
fix the warning  "1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
