### PR TITLE
Increase flexibility and security options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,25 @@ RUN CGO_ENABLED=0 go build
 
 FROM public.ecr.aws/docker/library/alpine:3.22.0
 
+ENV USER=eipcontroller
+ENV GROUPNAME=$USER
+ENV UID=5000
+ENV GID=5000
+
 COPY --from=builder /workspace/aws-pod-eip-controller /usr/local/bin/aws-pod-eip-controller
+
+RUN addgroup \
+    --gid "$GID" \
+    "$GROUPNAME" \
+&&  adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "$(pwd)" \
+    --ingroup "$GROUPNAME" \
+    --no-create-home \
+    --uid "$UID" \
+    $USER
+
+USER $UID
+
 CMD ["aws-pod-eip-controller"]

--- a/charts/aws-pod-eip-controller/templates/clusterrolebinding.yaml
+++ b/charts/aws-pod-eip-controller/templates/clusterrolebinding.yaml
@@ -13,5 +13,5 @@ roleRef:
   name: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.serviceAccountName }}
+    name: {{ .Values.serviceAccountName | default .Release.Name }}
     namespace: {{ .Release.Namespace }}

--- a/charts/aws-pod-eip-controller/templates/deployment.yaml
+++ b/charts/aws-pod-eip-controller/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         app.kubernetes.io/version: {{ .Chart.Version }}
     spec:
       serviceAccountName: {{ .Values.serviceAccountName | default .Release.Name }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{ .Values.podSecurityContext | toJson }}
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{ .Values.nodeSelector | toJson }}
       {{- end }}
@@ -37,6 +40,9 @@ spec:
       - name: {{ .Chart.Name }}
         image: {{ .Values.image }}
         imagePullPolicy: IfNotPresent
+        {{- if .Values.containerSecurityContext }}
+        securityContext: {{ .Values.containerSecurityContext | toJson }}
+        {{- end }}
         env:
           - name: PEC_LOG_LEVEL
             value: {{ .Values.logLevel }}

--- a/charts/aws-pod-eip-controller/templates/deployment.yaml
+++ b/charts/aws-pod-eip-controller/templates/deployment.yaml
@@ -23,10 +23,15 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/version: {{ .Chart.Version }}
     spec:
-      serviceAccountName: {{ .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName | default .Release.Name }}
       {{- if .Values.nodeSelector }}
-      nodeSelector:
-      {{ toYaml .Values.nodeSelector | indent 8 }}
+      nodeSelector: {{ .Values.nodeSelector | toJson }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{ .Values.tolerations | toJson }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{ .Values.affinity | toJson }}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
@@ -45,10 +50,6 @@ spec:
             value: {{ .Values.watchNamespace }}
           - name: PEC_RESYNC_PERIOD
             value: {{ quote .Values.resyncPeriod }}
-        resources:
-          limits:
-            cpu: 150m
-            memory: 256Mi
-          requests:
-            cpu: 150m
-            memory: 256Mi
+        {{- if .Values.resources }}
+        resources: {{ .Values.resources | toJson }}
+        {{- end }}

--- a/charts/aws-pod-eip-controller/templates/serviceaccount.yaml
+++ b/charts/aws-pod-eip-controller/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccountName }}
+  name: {{ .Values.serviceAccountName | default .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ .Chart.Name }}

--- a/charts/aws-pod-eip-controller/values.yaml
+++ b/charts/aws-pod-eip-controller/values.yaml
@@ -18,3 +18,5 @@ resources:
   requests:
     cpu: 150m
     memory: 256Mi
+podSecurityContext: {}
+containerSecurityContext: {}

--- a/charts/aws-pod-eip-controller/values.yaml
+++ b/charts/aws-pod-eip-controller/values.yaml
@@ -9,3 +9,12 @@ watchNamespace: ""
 createServiceAccount: false
 resyncPeriod: 0
 nodeSelector: {}
+tolerations: {}
+affinity: {}
+resources:
+  limits:
+    cpu: 150m
+    memory: 256Mi
+  requests:
+    cpu: 150m
+    memory: 256Mi


### PR DESCRIPTION
*Description of changes:*

This change adds elements to the helm chart to allow for a more flexible deployment, allowing the settings of tolerations (for tainted nodes) and affinity. It also uses the release name as the default serviceaccount name unless another has been specified.

A second commit in this PR adds a non-root user (5000/5000) and allows for security controls to indicate this does not need to run as root.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
